### PR TITLE
Fix: handling the first item added case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,9 @@ export function CartProvider({
       throw new Error('You must pass a `price` for new items')
 
     if (!currentItem)
-      return dispatch({ type: ADD_ITEM, payload: { ...item, quantity } })
+      const payload = { ...item,  quantity }
+      onItemAdd && onItemAdd(payload)
+      return dispatch({ type: ADD_ITEM, payload })
 
     const payload = { ...item, quantity: currentItem.quantity + quantity }
 


### PR DESCRIPTION
Fix: onItemAdd does not work for the first item added.
Just add onItemAdd && onItemAdd(payload) before "return" for the case where currentItem is null